### PR TITLE
Fix RegExp example to be more intuitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ And regular expressions
 
 ```javascript
 // Yeah, with RegExp too!
-match('Kvothe', /K*o*t*e/) // => true
+match('Kvothe', /K.ot.*e?/) // => true
 ```
 
 And everything together!


### PR DESCRIPTION
Current example code `match('Kvothe', /K*o*t*e/)` looks a bit weird.
Though `/K*o*t*e/` looks similar to `'Kvothe'`, it only matches the last character `e`.

This P-R fixes the pattern to be more RegExp-ish: `/K.ot.*e?/`.
