### PR TITLE
Normalize key order in object comparison.

### DIFF
--- a/lib/match.js
+++ b/lib/match.js
@@ -63,7 +63,7 @@ function compareArrays(array, expected) {
  * @api private
  */
 function compareObjects(object, expected) {
-  if (!compareArrays(Object.keys(object), Object.keys(expected))) return false;
+  if (!compareArrays(Object.keys(object).sort(), Object.keys(expected).sort())) return false;
   return Object.keys(expected).every(key => match(object[key], expected[key]));
 }
 


### PR DESCRIPTION
Key order should not be depended upon in the `compareObjects` call.
